### PR TITLE
Release 0.40.18

### DIFF
--- a/mongodb-inbox-outbox/src/main/resources/application.properties
+++ b/mongodb-inbox-outbox/src/main/resources/application.properties
@@ -16,6 +16,11 @@
 
 essentials.immutable-jackson-module-enabled=true
 
+essentials.reactive.event-bus-backpressure-buffer-size=1024
+essentials.reactive.overflow-max-retries=20
+essentials.reactive.queued-task-cap-factor=1.5
+#essentials.reactive.parallel-threads=4
+
 essentials.durable-queues.shared-queue-collection-name=durable_queues
 essentials.durable-queues.message-handling-timeout=5s
 essentials.durable-queues.polling-delay-interval-increment-factor=0.5
@@ -26,6 +31,7 @@ essentials.durable-queues.transactional-mode=singleoperationtransaction
 essentials.fenced-lock-manager.fenced-locks-collection-name=fenced_locks
 essentials.fenced-lock-manager.lock-confirmation-interval=5s
 essentials.fenced-lock-manager.lock-time-out=12s
+essentials.fenced-lock-manager.release-acquired-locks-in-case-of-i-o-exceptions-during-lock-confirmation=false
 
 spring.application.name=mongodb-inbox-outbox
 spring.kafka.bootstrap-servers=localhost:9092

--- a/pom.xml
+++ b/pom.xml
@@ -61,46 +61,46 @@
         <skipDependencyCheck>false</skipDependencyCheck>
 
         <!--Essentials versions-->
-        <essentials.version>0.40.15</essentials.version>
+        <essentials.version>0.40.18</essentials.version>
 
+        <spring-boot.version>3.2.12</spring-boot.version>
+        <spring-framework-bom.version>6.1.15</spring-framework-bom.version>
+        <reactor-bom.version>2023.0.12</reactor-bom.version>
+        <spring-data-mongodb.version>4.2.12</spring-data-mongodb.version>
+        <spring-data-jpa.version>3.2.12</spring-data-jpa.version>
         <objenesis.version>3.4</objenesis.version>
         <postgresql.version>42.7.4</postgresql.version>
         <slf4j.version>2.0.16</slf4j.version>
-        <spring-boot.version>3.2.9</spring-boot.version>
         <awaitility.version>4.2.2</awaitility.version>
-        <spring-data-mongodb.version>4.2.9</spring-data-mongodb.version>
-        <spring-data-jpa.version>3.2.9</spring-data-jpa.version>
         <assertj.version>3.26.3</assertj.version>
-        <mongodb-driver-sync.version>4.11.3</mongodb-driver-sync.version>
-        <log4j-to-slf4j.version>2.23.1</log4j-to-slf4j.version>
+        <mongodb-driver-sync.version>4.11.5</mongodb-driver-sync.version>
+        <log4j-to-slf4j.version>2.24.2</log4j-to-slf4j.version>
         <json-smart.version>2.5.1</json-smart.version>
         <json-path.version>2.9.0</json-path.version>
-        <snakeyaml.version>2.2</snakeyaml.version>
-        <micrometer.version>1.12.9</micrometer.version>
-        <micrometer-tracing.version>1.2.9</micrometer-tracing.version>
-        <netty-bom.version>4.1.112.Final</netty-bom.version>
-        <junit-bom.version>5.11.0</junit-bom.version>
-        <testcontainers-bom.version>1.20.1</testcontainers-bom.version>
-        <jdbi3-bom.version>3.45.4</jdbi3-bom.version>
-        <jackson-bom.version>2.17.2</jackson-bom.version>
-        <reactor-bom.version>2023.0.9</reactor-bom.version>
-        <spring-framework-bom.version>6.1.12</spring-framework-bom.version>
-        <mockito-bom.version>5.13.0</mockito-bom.version>
-        <logback.version>1.5.7</logback.version>
+        <snakeyaml.version>2.3</snakeyaml.version>
+        <micrometer.version>1.12.13</micrometer.version>
+        <micrometer-tracing.version>1.2.12</micrometer-tracing.version>
+        <netty-bom.version>4.1.115.Final</netty-bom.version>
+        <junit-bom.version>5.11.3</junit-bom.version>
+        <testcontainers-bom.version>1.20.4</testcontainers-bom.version>
+        <jdbi3-bom.version>3.47.0</jdbi3-bom.version>
+        <jackson-bom.version>2.17.3</jackson-bom.version>
+        <mockito-bom.version>5.14.2</mockito-bom.version>
+        <logback.version>1.5.12</logback.version>
         <avro.version>1.12.0</avro.version>
         <commons-compress.version>1.27.1</commons-compress.version>
         <xmlunit-core.version>2.10.0</xmlunit-core.version>
 
         <!-- Examples specific versions -->
-        <spring-kafka.version>3.1.8</spring-kafka.version>
-        <kafka-clients.version>3.8.0</kafka-clients.version>
-        <lombok.version>1.18.34</lombok.version>
+        <spring-kafka.version>3.1.10</spring-kafka.version>
+        <kafka-clients.version>3.9.0</kafka-clients.version>
+        <lombok.version>1.18.36</lombok.version>
         <prometheus-simpleclient.version>0.16.0</prometheus-simpleclient.version>
         <zipkin-reporter-brave.version>2.17.2</zipkin-reporter-brave.version>
         <loki-logback-appender.version>1.5.2</loki-logback-appender.version>
 
         <!-- Maven plugin versions -->
-        <maven-dependency-plugin.version>3.8.0</maven-dependency-plugin.version>
+        <maven-dependency-plugin.version>3.8.1</maven-dependency-plugin.version>
         <maven-project-info-reports-plugin.version>3.7.0</maven-project-info-reports-plugin.version>
         <maven-clean-plugin.version>3.4.0</maven-clean-plugin.version>
         <maven-install-plugin.version>3.1.3</maven-install-plugin.version>
@@ -109,17 +109,17 @@
         <maven-site-plugin.version>3.20.0</maven-site-plugin.version>
         <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
         <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
-        <maven-javadoc-plugin.version>3.7.0</maven-javadoc-plugin.version>
-        <maven-failsafe-plugin.version>3.4.0</maven-failsafe-plugin.version>
-        <maven-surefire-plugin.version>3.4.0</maven-surefire-plugin.version>
+        <maven-javadoc-plugin.version>3.10.1</maven-javadoc-plugin.version>
+        <maven-failsafe-plugin.version>3.5.2</maven-failsafe-plugin.version>
+        <maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
-        <versions-maven-plugin.version>2.17.1</versions-maven-plugin.version>
+        <versions-maven-plugin.version>2.18.0</versions-maven-plugin.version>
         <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
         <minimum-maven-version>3.8.8</minimum-maven-version>
-        <dependency-check-maven.version>10.0.3</dependency-check-maven.version>
+        <dependency-check-maven.version>11.1.0</dependency-check-maven.version>
         <flatten-maven-plugin.version>1.6.0</flatten-maven-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
-        <maven-gpg-plugin.version>3.2.5</maven-gpg-plugin.version>
+        <maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>
     </properties>
 
     <modules>
@@ -200,7 +200,7 @@
         <dependency>
             <groupId>org.xerial.snappy</groupId>
             <artifactId>snappy-java</artifactId>
-            <version>1.1.10.6</version>
+            <version>1.1.10.7</version>
         </dependency>
         <dependency>
             <groupId>org.yaml</groupId>

--- a/postgresql-cqrs/src/main/java/dk/cloudcreate/essentials/spring/examples/postgresql/cqrs/shipping/OrderShippingProcessor.java
+++ b/postgresql-cqrs/src/main/java/dk/cloudcreate/essentials/spring/examples/postgresql/cqrs/shipping/OrderShippingProcessor.java
@@ -16,8 +16,7 @@
 
 package dk.cloudcreate.essentials.spring.examples.postgresql.cqrs.shipping;
 
-import dk.cloudcreate.essentials.reactive.Handler;
-import dk.cloudcreate.essentials.reactive.command.AnnotatedCommandHandler;
+import dk.cloudcreate.essentials.reactive.command.*;
 import dk.cloudcreate.essentials.spring.examples.postgresql.cqrs.shipping.commands.*;
 import dk.cloudcreate.essentials.spring.examples.postgresql.cqrs.shipping.domain.*;
 import lombok.NonNull;
@@ -35,7 +34,7 @@ public class OrderShippingProcessor extends AnnotatedCommandHandler {
     }
 
     // Automatically runs in a transaction as it's forwarded by the DurableLocalCommandBus
-    @Handler
+    @CmdHandler
     void handle(RegisterShippingOrder cmd) {
         var existingOrder = shippingOrders.findOrder(cmd.orderId);
         if (existingOrder.isEmpty()) {
@@ -45,7 +44,7 @@ public class OrderShippingProcessor extends AnnotatedCommandHandler {
     }
 
     // Automatically runs in a transaction as it's forwarded by the DurableLocalCommandBus
-    @Handler
+    @CmdHandler
     void handle(ShipOrder cmd) {
         log.debug("===> Initiating Shipping of Order '{}'", cmd.orderId);
         var existingOrder = shippingOrders.getOrder(cmd.orderId);

--- a/postgresql-cqrs/src/main/java/dk/cloudcreate/essentials/spring/examples/postgresql/cqrs/shipping/adapters/web/ShippingAPI.java
+++ b/postgresql-cqrs/src/main/java/dk/cloudcreate/essentials/spring/examples/postgresql/cqrs/shipping/adapters/web/ShippingAPI.java
@@ -29,11 +29,11 @@ public class ShippingAPI {
 
     @PostMapping("/register-order")
     public void registerShippingOrder(@RequestBody RegisterShippingOrder cmd) {
-        commandBus.send(cmd);
+        commandBus.sendAndDontWait(cmd);
     }
 
     @PostMapping("/ship-order")
     public void shipOrder(@RequestBody ShipOrder cmd) {
-        commandBus.send(cmd);
+        commandBus.sendAndDontWait(cmd);
     }
 }

--- a/postgresql-cqrs/src/main/resources/application.properties
+++ b/postgresql-cqrs/src/main/resources/application.properties
@@ -16,6 +16,11 @@
 
 essentials.immutable-jackson-module-enabled=true
 
+essentials.reactive.event-bus-backpressure-buffer-size=1024
+essentials.reactive.overflow-max-retries=20
+essentials.reactive.queued-task-cap-factor=1.5
+#essentials.reactive.parallel-threads=4
+
 essentials.event-store.identifier-column-type=text
 essentials.event-store.json-column-type=jsonb
 essentials.event-store.use-event-stream-gap-handler=true
@@ -32,6 +37,7 @@ essentials.durable-queues.verbose-tracing=false
 essentials.fenced-lock-manager.fenced-locks-table-name=fenced_locks
 essentials.fenced-lock-manager.lock-confirmation-interval=5s
 essentials.fenced-lock-manager.lock-time-out=12s
+essentials.fenced-lock-manager.release-acquired-locks-in-case-of-i-o-exceptions-during-lock-confirmation=false
 
 spring.application.name=postgresql-cqrs
 

--- a/postgresql-cqrs/src/main/resources/logback-spring.xml
+++ b/postgresql-cqrs/src/main/resources/logback-spring.xml
@@ -36,6 +36,7 @@
     </appender>
 
     <logger name="dk.cloudcreate.essentials" level="DEBUG"/>
+    <logger name="dk.cloudcreate.essentials.spring.examples.postgresql.cqrs.shipping.adapters.kafka.outgoing.ShippingEventKafkaPublisher" level="TRACE"/>
     <logger name="dk.cloudcreate.essentials.components.foundation.transaction" level="INFO"/>
     <logger name="dk.cloudcreate.essentials.components.distributed.fencedlock.postgresql.PostgresqlFencedLockManager" level="INFO"/>
     <logger name="dk.cloudcreate.essentials.shared.interceptor.DefaultInterceptorChain" level="DEBUG"/>
@@ -44,6 +45,7 @@
     <logger name="dk.cloudcreate.essentials.components.foundation.messaging.queue.DurableQueueConsumer.MessageHandlingFailures" level="DEBUG"/>
     <logger name="dk.cloudcreate.essentials.components.foundation.messaging.queue.QueuePollingOptimizer.SimpleQueuePollingOptimizer" level="DEBUG"/>
     <logger name="dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription" level="INFO"/>
+    <logger name="dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription.PostgresqlDurableSubscriptionRepository" level="INFO"/>
     <logger name="dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.gap" level="INFO"/>
     <logger name="dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.EventStore.PollingEventStream" level="INFO"/>
 

--- a/postgresql-inbox-outbox/src/main/resources/application.properties
+++ b/postgresql-inbox-outbox/src/main/resources/application.properties
@@ -16,6 +16,11 @@
 
 essentials.immutable-jackson-module-enabled=true
 
+essentials.reactive.event-bus-backpressure-buffer-size=1024
+essentials.reactive.overflow-max-retries=20
+essentials.reactive.queued-task-cap-factor=1.5
+#essentials.reactive.parallel-threads=4
+
 essentials.durable-queues.shared-queue-table-name=durable_queues
 essentials.durable-queues.polling-delay-interval-increment-factor=0.5
 essentials.durable-queues.max-polling-interval=2s
@@ -25,6 +30,7 @@ essentials.durable-queues.transactional-mode=singleoperationtransaction
 essentials.fenced-lock-manager.fenced-locks-table-name=fenced_locks
 essentials.fenced-lock-manager.lock-confirmation-interval=5s
 essentials.fenced-lock-manager.lock-time-out=12s
+essentials.fenced-lock-manager.release-acquired-locks-in-case-of-i-o-exceptions-during-lock-confirmation=false
 
 spring.jpa.generate-ddl=true
 spring.jpa.hibernate.ddl-auto=create-drop


### PR DESCRIPTION
- Added `LocalEventBus`/`EventStoreEventBus` reactive properties `essentials.reactive.*` to the Spring configuration properties
- Switched to use `CommandBus.sendAndDontWait` in `postgresql-cqrs`'s `ShippingAPI`
- Switched to using `@CmdHandler` in  `postgresql-cqrs`'s `OrderShippingProcessor`
- Added `essentials.fenced-lock-manager.release-acquired-locks-in-case-of-i-o-exceptions-during-lock-confirmation` to the Spring configuration properties

Updated to Essentials 0.40.18

Updated 3rd party dependencies
- Spring Boot 3.2.12
- Spring Framework 6.1.15
- Reactor 2023.0.12
- Spring Data MongoDB 4.2.12
- Spring Data JPA 3.2.12
- mongodb-driver-sync 4.11.5
- log4j-to-slf4j 2.24.2
- micrometer 1.12.13
- micrometer-tracing 1.2.12
- netty 4.1.115.Final
- JUnit 5.11.3
- TestContainers 1.20.4
- JDBI 3.47.0
- Jackson 2.18.1
- LogBack 1.5.12
- Lombok 1.18.36
- Spring-Kafka 3.1.10
- Kafka-clients 3.9.0
- snappy-java 1.1.10.7

Updated Maven plugins
- maven-javadoc-plugin 3.10.1
- maven-dependency-plugin 3.8.1
- maven-failsafe-plugin / maven-surefire-plugin 3.5.2
- versions-maven-plugin 2.18.0
- dependency-check-maven 11.1.0
- maven-pgp-plugin 3.2.7